### PR TITLE
New pandas syntax for column indexing

### DIFF
--- a/causalinference/core/propensity.py
+++ b/causalinference/core/propensity.py
@@ -104,8 +104,10 @@ def form_matrix(X, lin, qua):
 	mat[:, 0] = 1  # constant term
 
 	current_col = 1
+	if lin == 'all':
+		lin = list(range(len(X.columns)))
 	if lin:
-		mat[:, current_col:current_col+len(lin)] = X[:, lin]
+		mat[:, current_col:current_col+len(lin)] = X[X.columns[lin]]
 		current_col += len(lin)
 	for term in qua:  # qua is a list of tuples of column numbers
 		mat[:, current_col] = X[:, term[0]] * X[:, term[1]]


### PR DESCRIPTION
- Pandas syntax changed for column indexing, new version `X[X.columns[lin]]` 
- lin for "all" was not defined

Fixes following error:
```
Traceback (most recent call last):
  File "/Users/julian/opt/anaconda3/envs/uw_bridging/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 2889, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 75, in pandas._libs.index.IndexEngine.get_loc
TypeError: '(slice(None, None, None), [0, 1])' is an invalid key
```